### PR TITLE
Fix iptables

### DIFF
--- a/puppet/manifests/site.pp.dist
+++ b/puppet/manifests/site.pp.dist
@@ -47,6 +47,9 @@ $syslog_servers = [
                   ]
 
 $puppet_server = 'puppet.example.com'
+$puppet_client_range = [
+                        '10.0.0.0/8',
+                       ]
 
 # where do publication servers get their data?
 # TODO: handle multiple sources, distribute amongst pub servers

--- a/puppet/modules/rpki/manifests/init.pp
+++ b/puppet/modules/rpki/manifests/init.pp
@@ -132,6 +132,7 @@ class rpki::role::puppet_master {
 
   class { 'rpki::iptables':
     rolePuppetServer => true,
+    puppetClients => $puppet_client_range,
     sshRestrictSource => $ssh_client_range,
     sshUnrestrictedPort => $ssh_unrestricted_port,
   }

--- a/puppet/modules/rpki/manifests/iptables.pp
+++ b/puppet/modules/rpki/manifests/iptables.pp
@@ -33,6 +33,7 @@ class rpki::iptables(
   # puppet server
   $rolePuppetServer = $::rpki::params::rolePuppetServer,
   $puppetPort = $::rpki::params::puppetPort,
+  $puppetClients = $::rpki::params::puppetClients,
 
   # rpki CA
   $roleRPKI_CA = $::rpki::params::roleRPKI_CA,

--- a/puppet/modules/rpki/manifests/params.pp
+++ b/puppet/modules/rpki/manifests/params.pp
@@ -26,6 +26,7 @@ class rpki::params () {
     # puppet server
     $rolePuppetServer = false
     $puppetPort = 8140
+    $puppetClients = []
     $pup_def_master = '/etc/default/puppetmaster'
     # -- for git_cron script
     $gitCron_infraRepoDir = '/var/lib/rpki-mgmt'

--- a/puppet/modules/rpki/manifests/params.pp
+++ b/puppet/modules/rpki/manifests/params.pp
@@ -26,6 +26,7 @@ class rpki::params () {
     # puppet server
     $rolePuppetServer = false
     $puppetPort = 8140
+    $pup_def_master = '/etc/default/puppetmaster'
     # -- for git_cron script
     $gitCron_infraRepoDir = '/var/lib/rpki-mgmt'
     $gitCron_infraRepoName = 'rpki-mgmt.git'
@@ -48,12 +49,14 @@ class rpki::params () {
 
     case $::lsbmajdistrelease {
       '8': {
-        $pupdeffile = '/etc/default/puppetmaster'
+        $pup_def_agent = undef
         $ipt_pkg = 'netfilter-persistent'
+        $apt_path = 'APTng/rpki.$::lsbdistcodename.list'
       }
       '7': {
-        $pupdeffile = '/etc/default/puppet.conf'
+        $pup_def_agent = '/etc/default/puppet'
         $ipt_pkg = 'iptables-persistent'
+        $apt_path = 'APT/rpki.$::lsbdistcodename.list'
       }
       default: { fail("debian release $::lsbmajdistrelease not supported") }
     }

--- a/puppet/modules/rpki/manifests/puppet_config.pp
+++ b/puppet/modules/rpki/manifests/puppet_config.pp
@@ -17,14 +17,16 @@ class rpki::puppet_config(
 {
   package { 'puppet':
     ensure => 'installed',
-  } ->
-  file_line { 'start puppet on boot': # xxx: debian-ism
-    ensure => present,
-    match  => '^#?START=',
-    line   => 'START=true',
-    path   => $rpki::params::pupdeffile,
-    notify => Service["puppet"],
-  } ->
+  }
+  if $rpki::params::pup_def_agent != undef {
+    file_line { 'start puppet on boot': # xxx: debian-ism
+      ensure => present,
+      match  => '^#?START=',
+      line   => 'START=true',
+      path   => $rpki::params::pup_def_agent,
+      notify => Service["puppet"],
+    }
+  }
   ini_setting { 'puppet server':
     ensure => 'present',
     path   => '/etc/puppet/puppet.conf',

--- a/puppet/modules/rpki/manifests/puppet_master.pp
+++ b/puppet/modules/rpki/manifests/puppet_master.pp
@@ -25,6 +25,17 @@ class rpki::puppet_master(
   package { ['git', 'puppetmaster', 'puppet-lint']:
     ensure => 'installed',
   }
+
+  if $rpki::params::pup_def_master != undef {
+    file_line { 'start puppet on boot': # xxx: debian-ism
+      ensure => present,
+      match  => '^#?START=',
+      line   => 'START=true',
+      path   => $rpki::params::pup_def_master,
+      notify => Service["puppet"],
+    }
+  }
+
   file { "/usr/local/sbin/git_cron.sh":
     source  => "puppet:///modules/rpki/git_cron.sh",
     ensure => 'file',

--- a/puppet/modules/rpki/manifests/rpki_repo.pp
+++ b/puppet/modules/rpki/manifests/rpki_repo.pp
@@ -22,7 +22,7 @@ define rpki::rpki_repo()
   }  -> Package <| |>
 
   exec{'get rpki.net APT repo':
-    command => "/usr/bin/wget -q -O /etc/apt/sources.list.d/rpki.list http://download.rpki.net/APT/rpki.$::lsbdistcodename.list",
+    command => "/usr/bin/wget -q -O /etc/apt/sources.list.d/rpki.list http://download.rpki.net/$rpki::params::apt_path && /usr/bin/apt-get update",
     creates => "/etc/apt/sources.list.d/rpki.list",
   }
   file{'/etc/apt/sources.list.d/rpki.list':

--- a/puppet/modules/rpki/templates/iptables.v4.erb
+++ b/puppet/modules/rpki/templates/iptables.v4.erb
@@ -35,7 +35,13 @@
 <% end -%>
 <% if @rolePuppetServer == true -%>
 # puppet master
+<% if @puppetClients.empty? -%>
 -A INPUT -p tcp -m state --state NEW --dport <%= @puppetPort %> -j ACCEPT
+<% else -%>
+<% puppetClients.each do |source| -%>
+-A INPUT -s <%= source %> -p tcp -m state --state NEW --dport <%= @puppetPort %> -j ACCEPT
+<% end -%>
+<% end -%>
 
 <% end -%>
 <% if @roleRPKI_CA == true -%>


### PR DESCRIPTION
When the puppet iptables module runs it fails to drop the iptables configuration file, because the /etc/iptables directory does not first exist. This creates the directory.
